### PR TITLE
Update libreddit image

### DIFF
--- a/nix/docker-compose/web-dragon/docker-compose.yml
+++ b/nix/docker-compose/web-dragon/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Reddit frontend
   libreddit:
-    image: spikecodes/libreddit:latest
+    image: libreddit/libreddit:latest
     container_name: libreddit
     environment:
       LIBREDDIT_DEFAULT_AUTOPLAY_VIDEOS: "true"


### PR DESCRIPTION
Following the move of libreddit to its own organization, the old Docker image has been retired and moved to `libreddit/libreddit` ([source](https://hub.docker.com/r/spikecodes/libreddit)).